### PR TITLE
Fix edge-case of returning a 404 when queue is empty for publisher

### DIFF
--- a/src/main/java/org/atlasapi/feeds/youview/statistics/MongoFeedStatisticsStore.java
+++ b/src/main/java/org/atlasapi/feeds/youview/statistics/MongoFeedStatisticsStore.java
@@ -42,7 +42,7 @@ public class MongoFeedStatisticsStore implements FeedStatisticsResolver {
     public Optional<FeedStatistics> resolveFor(Publisher publisher) {
         Optional<Duration> latency = calculateLatency(publisher);
         if (!latency.isPresent()) {
-            return Optional.absent();
+            return Optional.of(new FeedStatistics(publisher, 0, Duration.ZERO));
         }
 
         int queueSize = calculateCurrentQueueSize(publisher);

--- a/src/test/java/org/atlasapi/feeds/youview/statistics/MongoFeedStatisticsStoreTest.java
+++ b/src/test/java/org/atlasapi/feeds/youview/statistics/MongoFeedStatisticsStoreTest.java
@@ -2,7 +2,6 @@ package org.atlasapi.feeds.youview.statistics;
 
 import static org.atlasapi.feeds.tasks.Destination.DestinationType.YOUVIEW;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import org.atlasapi.feeds.tasks.Action;
 import org.atlasapi.feeds.tasks.Status;
@@ -33,9 +32,11 @@ public class MongoFeedStatisticsStoreTest {
     private final MongoFeedStatisticsStore store = new MongoFeedStatisticsStore(mongo, taskStore, clock, YOUVIEW);
 
     @Test
-    public void testFetchOfAbsentDayAndPublisherReturnsAbsent() {
-        Optional<FeedStatistics> stats = store.resolveFor(Publisher.BT_BLACKOUT);
-        assertFalse("Feed stats should not be returned if no record exists for the provided publisher and day", stats.isPresent());
+    public void testFetchOfAbsentDayAndPublisherReturnsZeroLatencyAndSize() {
+        Optional<FeedStatistics> statsOptional = store.resolveFor(Publisher.BT_BLACKOUT);
+        FeedStatistics stats = statsOptional.get();
+        assertEquals(0, stats.queueSize());
+        assertEquals(Duration.ZERO, stats.updateLatency());
     }
 
     @Test


### PR DESCRIPTION
**NOTE**: this fixes the edge-case of returning a 404 instead of 200 with results 0 when the queue for a publisher is fully processed and there are no jobs. However, this also means that we're not handling legit 404s as such and are returning 0 latency and queue size for those, which I think is technically correct.