### PR TITLE
Do not default availability dates to now if null

### DIFF
--- a/src/main/java/org/atlasapi/feeds/youview/nitro/NitroOnDemandLocationGenerator.java
+++ b/src/main/java/org/atlasapi/feeds/youview/nitro/NitroOnDemandLocationGenerator.java
@@ -219,7 +219,7 @@ public class NitroOnDemandLocationGenerator implements OnDemandLocationGenerator
 
     private XMLGregorianCalendar generateAvailabilityStart(Location location) {
         Policy policy = location.getPolicy();
-        if (policy == null) {
+        if (policy == null || policy.getAvailabilityStart() == null) {
             return null;
         }
         return TvAnytimeElementFactory.gregorianCalendar(policy.getAvailabilityStart());
@@ -227,7 +227,7 @@ public class NitroOnDemandLocationGenerator implements OnDemandLocationGenerator
 
     private XMLGregorianCalendar generateAvailabilityEnd(Location location) {
         Policy policy = location.getPolicy();
-        if (policy == null) {
+        if (policy == null || policy.getAvailabilityEnd() == null) {
             return null;
         }
         return TvAnytimeElementFactory.gregorianCalendar(policy.getAvailabilityEnd());


### PR DESCRIPTION
DateTimeFormatter.print() inteprets null as now, rather
than null. We therefore need to not call it in the case
of no availability date to avoid defaulting the
availability to now.