### PR TITLE
Allow trailing characters after date-based titles

### DIFF
--- a/src/main/java/org/atlasapi/feeds/youview/nitro/NitroEpisodeNumberPrefixAddingContentTitleGenerator.java
+++ b/src/main/java/org/atlasapi/feeds/youview/nitro/NitroEpisodeNumberPrefixAddingContentTitleGenerator.java
@@ -8,7 +8,8 @@ import org.atlasapi.media.entity.Episode;
 
 public class NitroEpisodeNumberPrefixAddingContentTitleGenerator implements ContentTitleGenerator {
     
-    private static Pattern DATE_PATTERN = Pattern.compile("^\\d{2}\\/\\d{2}\\/\\d{4}$");
+    private static final int START_OF_STRING = 0;
+    private static Pattern DATE_PATTERN = Pattern.compile("^\\d{2}\\/\\d{2}\\/\\d{4}");
     private static Pattern EPISODE_NUMBER_PATTERN = Pattern.compile("^(Episode|Episodes|Pennod|Pennodau|Part|Week) [\\d]+(.*)?");
     
     public String titleFor(Content content) {
@@ -22,8 +23,8 @@ public class NitroEpisodeNumberPrefixAddingContentTitleGenerator implements Cont
         
         if (episodeTitle == null 
                 || episode.getEpisodeNumber() == null
-                || DATE_PATTERN.matcher(episodeTitle).matches()
-                || EPISODE_NUMBER_PATTERN.matcher(episodeTitle).matches()) {
+                || DATE_PATTERN.matcher(episodeTitle).find(START_OF_STRING)
+                || EPISODE_NUMBER_PATTERN.matcher(episodeTitle).find(START_OF_STRING)) {
             return episodeTitle;
         } else {
             return String.format("%d. %s", episode.getEpisodeNumber(), episodeTitle);

--- a/src/test/java/org/atlasapi/feeds/youview/nitro/NitroEpisodeNumberPrefixAddingContentTitleGeneratorTest.java
+++ b/src/test/java/org/atlasapi/feeds/youview/nitro/NitroEpisodeNumberPrefixAddingContentTitleGeneratorTest.java
@@ -50,6 +50,16 @@ public class NitroEpisodeNumberPrefixAddingContentTitleGeneratorTest {
     }
     
     @Test
+    public void testEpisodeWithDatePrefixIsNotMutated() {
+        Brand brand = createBrand("Brand");
+        Episode episode = createEpisode(brand, null);
+        String episodeTitle = "01/02/2014 Test";
+        episode.setTitle(episodeTitle);
+        
+        assertEquals("01/02/2014 Test", generator.titleFor(episode));
+    }
+    
+    @Test
     public void testNullEpisodeNumbersAreNotMutated() {
         Brand brand = createBrand("Brand");
         Episode episode = createEpisode(brand, null);
@@ -66,6 +76,17 @@ public class NitroEpisodeNumberPrefixAddingContentTitleGeneratorTest {
         Episode episode = createEpisode(brand, null);
         episode.setEpisodeNumber(1);
         String episodeTitle = "Pennod 33";
+        episode.setTitle(episodeTitle);
+        
+        assertEquals(episodeTitle, generator.titleFor(episode));
+    }
+    
+    @Test
+    public void testEpisodePrefixedWithPennodWithSuffixIsNotMutated() {
+        Brand brand = createBrand("Brand");
+        Episode episode = createEpisode(brand, null);
+        episode.setEpisodeNumber(1);
+        String episodeTitle = "Pennod 33 suffix";
         episode.setTitle(episodeTitle);
         
         assertEquals(episodeTitle, generator.titleFor(episode));


### PR DESCRIPTION
If a title starts with a date, the episode number should
not be prefixed. Example being Eastenders where there are
occasionally two episodes on the same day "dd/mm/yyyy Part 1"
etc.