### PR TITLE
Use existing OD/PI logic to determine if NoItemsException is a failure

### DIFF
--- a/src/main/java/org/atlasapi/feeds/radioplayer/upload/RadioPlayerOdUploadTask.java
+++ b/src/main/java/org/atlasapi/feeds/radioplayer/upload/RadioPlayerOdUploadTask.java
@@ -1,8 +1,5 @@
 package org.atlasapi.feeds.radioplayer.upload;
 
-import static org.atlasapi.feeds.radioplayer.upload.FileType.OD;
-import static org.atlasapi.persistence.logging.AdapterLogEntry.debugEntry;
-
 import java.util.Set;
 
 import org.atlasapi.feeds.radioplayer.RadioPlayerOdFeedSpec;
@@ -11,10 +8,13 @@ import org.atlasapi.feeds.radioplayer.outputting.NoItemsException;
 import org.atlasapi.feeds.upload.FileUploadService;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.logging.AdapterLog;
+
+import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
-import com.google.common.base.Optional;
+import static org.atlasapi.feeds.radioplayer.upload.FileType.OD;
+import static org.atlasapi.persistence.logging.AdapterLogEntry.debugEntry;
 
 public class RadioPlayerOdUploadTask extends RadioPlayerUploadTask {
     
@@ -23,9 +23,10 @@ public class RadioPlayerOdUploadTask extends RadioPlayerUploadTask {
     }
 
     @Override
-    protected void logNotItemsException(NoItemsException e) {
+    protected boolean isFailure(NoItemsException e) {
         if( log != null) {
             log.record(debugEntry().withDescription("No items for " + spec).withSource(getClass()).withCause(e));
         }
+        return false;
     }
 }

--- a/src/main/java/org/atlasapi/feeds/radioplayer/upload/RadioPlayerPiUploadTask.java
+++ b/src/main/java/org/atlasapi/feeds/radioplayer/upload/RadioPlayerPiUploadTask.java
@@ -1,9 +1,5 @@
 package org.atlasapi.feeds.radioplayer.upload;
 
-import static org.atlasapi.feeds.radioplayer.upload.FileType.PI;
-import static org.atlasapi.persistence.logging.AdapterLogEntry.debugEntry;
-import static org.atlasapi.persistence.logging.AdapterLogEntry.errorEntry;
-
 import org.atlasapi.feeds.radioplayer.RadioPlayerPiFeedSpec;
 import org.atlasapi.feeds.radioplayer.RadioPlayerService;
 import org.atlasapi.feeds.radioplayer.RadioPlayerServices;
@@ -11,9 +7,15 @@ import org.atlasapi.feeds.radioplayer.outputting.NoItemsException;
 import org.atlasapi.feeds.upload.FileUploadService;
 import org.atlasapi.media.entity.Publisher;
 import org.atlasapi.persistence.logging.AdapterLog;
-import org.joda.time.LocalDate;
+import org.atlasapi.persistence.logging.AdapterLogEntry;
 
 import com.metabroadcast.common.time.DateTimeZones;
+
+import org.joda.time.LocalDate;
+
+import static org.atlasapi.feeds.radioplayer.upload.FileType.PI;
+import static org.atlasapi.persistence.logging.AdapterLogEntry.debugEntry;
+import static org.atlasapi.persistence.logging.AdapterLogEntry.errorEntry;
 
 public class RadioPlayerPiUploadTask extends RadioPlayerUploadTask {
 
@@ -22,13 +24,24 @@ public class RadioPlayerPiUploadTask extends RadioPlayerUploadTask {
     }
 
     @Override
-    protected void logNotItemsException(NoItemsException e) {
-        if( log != null) {
-            if (!spec.getDay().isAfter(new LocalDate(DateTimeZones.UTC).plusDays(1)) && !RadioPlayerServices.untracked.contains(spec.getService())) {
-                log.record(errorEntry().withDescription("No items for " + spec).withSource(getClass()).withCause(e));
-            } else {
-                log.record(debugEntry().withDescription("No items for " + spec).withSource(getClass()).withCause(e));
-            }
+    protected boolean isFailure(NoItemsException e) {
+        if (!spec.getDay().isAfter(new LocalDate(DateTimeZones.UTC).plusDays(1))
+                && !RadioPlayerServices.untracked.contains(spec.getService())) {
+            log(errorEntry().withDescription("No items for " + spec)
+                    .withSource(getClass())
+                    .withCause(e));
+            return true;
+        } else {
+            log(debugEntry().withDescription("No items for " + spec)
+                    .withSource(getClass())
+                    .withCause(e));
+            return false;
+        }
+    }
+
+    private void log(AdapterLogEntry adapterLogEntry) {
+        if (log != null) {
+            log.record(adapterLogEntry);
         }
     }
 }


### PR DESCRIPTION
- Do not stop upload for a NoItemsException if it is not considered a
failure. Instead resume upload for the remaining services and mark
the result as a debug entry.