### PR TITLE
Allow overriding of entire service URI

### DIFF
--- a/src/main/java/org/atlasapi/feeds/radioplayer/RadioPlayerService.java
+++ b/src/main/java/org/atlasapi/feeds/radioplayer/RadioPlayerService.java
@@ -4,11 +4,12 @@ import com.google.common.primitives.Ints;
 
 public class RadioPlayerService {
 
+    public static final String SERVICE_URI_PREFIX = "http://www.bbc.co.uk/services/";
+
     private final int radioplayerId;
     private final String name;
     private String serviceUri;
     private String dabServiceId = "00.0000.0000.0";
-    private String scheduleUri;
     private String ionId;
     private String masterBrandId;
 
@@ -57,21 +58,20 @@ public class RadioPlayerService {
     }
 
     public RadioPlayerService withServiceUriSuffix(String serviceUri) {
+        this.serviceUri = SERVICE_URI_PREFIX + serviceUri;
+        return this;
+    }
+
+    public RadioPlayerService withServiceUri(String serviceUri) {
         this.serviceUri = serviceUri;
         return this;
     }
 
     public String getServiceUri() {
-        return "http://www.bbc.co.uk/services/" + (serviceUri != null ? serviceUri : name);
-    }
-
-    public RadioPlayerService withScheduleUri(String scheduleUri) {
-        this.scheduleUri = scheduleUri;
-        return this;
-    }
-
-    public String getScheduleUri() {
-        return (scheduleUri != null) ? scheduleUri : String.format("http://www.bbc.co.uk/%s/programmes/schedules", name);
+        if (serviceUri != null) {
+            return serviceUri;
+        }
+        return SERVICE_URI_PREFIX + name;
     }
 
     @Override

--- a/src/main/java/org/atlasapi/feeds/radioplayer/RadioPlayerServices.java
+++ b/src/main/java/org/atlasapi/feeds/radioplayer/RadioPlayerServices.java
@@ -55,7 +55,7 @@ public class RadioPlayerServices {
 			add(new RadioPlayerService(318, "leicester")).
 			add(new RadioPlayerService(319, "lincolnshire")).
 			add(new RadioPlayerService(320, "manchester")
-					.withScheduleUri("http://ref.atlasapi.org/channels/pressassociation.com/1870")).
+					.withServiceUri("http://ref.atlasapi.org/channels/pressassociation.com/1870")).
 			add(new RadioPlayerService(321, "merseyside")).
 			add(new RadioPlayerService(322, "newcastle")).
 			add(new RadioPlayerService(323, "norfolk")).
@@ -65,7 +65,7 @@ public class RadioPlayerServices {
 			add(new RadioPlayerService(327, "sheffield")).
 			add(new RadioPlayerService(328, "shropshire")).
 			add(new RadioPlayerService(329, "solent")
-					.withScheduleUri("http://ref.atlasapi.org/channels/solent961fm")).
+					.withServiceUri("http://ref.atlasapi.org/channels/solent961fm")).
 			add(new RadioPlayerService(330, "somerset")
 					.withIonServiceId("bbc_radio_somerset_sound")).
 			add(new RadioPlayerService(331, "stoke")).
@@ -82,7 +82,6 @@ public class RadioPlayerServices {
 					.withIonServiceId("bbc_wm")).
 			add(new RadioPlayerService(340, "radio1")
 					.withServiceUriSuffix("radio1/england")
-					.withScheduleUri("http://www.bbc.co.uk/radio1/programmes/schedules/england")
 					.withIonServiceId("bbc_radio_one")).
 			add(new RadioPlayerService(341, "1xtra")
 					.withIonServiceId("bbc_1xtra")).
@@ -92,7 +91,6 @@ public class RadioPlayerServices {
 					.withIonServiceId("bbc_radio_three")).
 			add(new RadioPlayerService(344, "radio4")
 					.withServiceUriSuffix("radio4/fm")
-					.withScheduleUri("http://www.bbc.co.uk/radio4/programmes/schedules/fm")
 					.withIonServiceId("bbc_radio_fourfm")
 					.withMasterBrandId("bbc_radio_four")).
 			add(new RadioPlayerService(345, "5live")
@@ -107,7 +105,6 @@ public class RadioPlayerServices {
 					.withIonServiceId("bbc_world_service")).
 			add(new RadioPlayerService(351, "radioscotland")
 					.withServiceUriSuffix("radioscotland/fm")
-					.withScheduleUri("http://www.bbc.co.uk/radioscotland/programmes/schedules/fm")
 					.withIonServiceId("bbc_radio_scotland_fm")
 					.withMasterBrandId("bbc_radio_scotland")).
 			add(new RadioPlayerService(352, "radionangaidheal")
@@ -118,7 +115,6 @@ public class RadioPlayerServices {
 					.withIonServiceId("bbc_radio_foyle")).
 			add(new RadioPlayerService(355, "radiowales")
 					.withServiceUriSuffix("radiowales/fm")
-					.withScheduleUri("http://www.bbc.co.uk/radiowales/programmes/schedules/fm")
 					.withIonServiceId("bbc_radio_wales_fm")).
 			add(new RadioPlayerService(356, "radiocymru")
 					.withIonServiceId("bbc_radio_cymru")).


### PR DESCRIPTION
This allows the service URI to be specified in its entirety
for cases where the service URI doesn't match the usual
pattern.