### PR TITLE
Stop resending deletes for ondemands

### DIFF
--- a/src/main/java/org/atlasapi/feeds/youview/persistence/HashType.java
+++ b/src/main/java/org/atlasapi/feeds/youview/persistence/HashType.java
@@ -4,5 +4,6 @@ public enum HashType {
     CONTENT,
     VERSION,
     BROADCAST,
-    ON_DEMAND
+    ON_DEMAND,
+    DELETE
 }


### PR DESCRIPTION
YouView revokes are handled via an HTTP DELETE request and don't care about the payload.
Since only the payload was used to make sure we don't send transactions for unchanged
entities, it didn't handle deletes. This fixes the hashing to handle deletes.