### PR TITLE
Skip uploading versions with null durations to YouView

### DIFF
--- a/src/main/java/org/atlasapi/feeds/youview/FilterFactory.java
+++ b/src/main/java/org/atlasapi/feeds/youview/FilterFactory.java
@@ -21,8 +21,9 @@ public class FilterFactory {
         return new Predicate<ItemAndVersion>() {
             @Override
             public boolean apply(ItemAndVersion input) {
-                return hasBeenUpdated(input.item(), updatedSince)
-                        || hasBeenUpdated(input.version(), updatedSince);
+                return input.version().getDuration() != null
+                        && (hasBeenUpdated(input.item(), updatedSince)
+                        || hasBeenUpdated(input.version(), updatedSince));
             }
         };
     }


### PR DESCRIPTION
This is due to us historically ingesting duff data. It's purely a Nitro issue, but we've ingested some of these
and need to filter them out, as YouView will reject the transaction anyway.