### PR TITLE
Upgrade to Spring 4.0.9, Servlet-API 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,8 +206,8 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>${javax.servlet-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -341,7 +341,10 @@
 
 	<properties>
 		<atlas.version>${project.version}</atlas.version>
-		<spring.version>3.0.5.RELEASE</spring.version>
+
+		<spring.version>4.0.9.RELEASE</spring.version>
+		<javax.servlet-api.version>3.0.1</javax.servlet-api.version>
+
 		<jacoco.version>0.7.5.201505241946</jacoco.version>
 
 		<sonar.jacoco.itReportPath>${project.basedir}/target/jacoco-it.exec</sonar.jacoco.itReportPath>


### PR DESCRIPTION
- The intention is to get a version of Spring/ASM that supports Java
  8 while making the minimum number of code changes
- Spring 4.2.x was avoided because it removes some deprecated APIs we
  are using
- Spring 4.1.x was avoided because it mandates use of Jackson 2
- Servlet-API 3.1.0 was avoided because there is a breaking API
  change in one of its interfaces