### PR TITLE
Fudge OD dates back to past if they're expired

### DIFF
--- a/src/main/java/org/atlasapi/feeds/tasks/youview/creation/OnDemandDateFudger.java
+++ b/src/main/java/org/atlasapi/feeds/tasks/youview/creation/OnDemandDateFudger.java
@@ -1,0 +1,58 @@
+package org.atlasapi.feeds.tasks.youview.creation;
+
+import org.atlasapi.feeds.youview.hierarchy.ItemOnDemandHierarchy;
+import org.atlasapi.media.entity.Location;
+import org.atlasapi.media.entity.Policy;
+
+import com.metabroadcast.common.time.Clock;
+
+import org.joda.time.DateTime;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/** This exists because
+ * 1. The BBC "sometimes" completely nuke availabilites
+ * 2. We decided to handle that case in R4 and send DELETEs for those to YV
+ * 3. In R3 we decided to decrease the amount of "entity unchanged" transactions generated
+ *    via payload hashes
+ * 4. This then means that BBC flap an availability, we send both the payload and the matching
+ *    DELETE, and then nothing once BBC republish it, because we have both hashes now
+ *
+ * This class is used in the JAXB generator to artificially fudge the start dates of Locations if
+ * the start date is in the past, thus changing the payload, busthing the hash and resulting in the
+ * OnDemand being uploaded. What we do is hard.
+ */
+public class OnDemandDateFudger {
+
+    private final Clock clock;
+
+    private OnDemandDateFudger(Clock clock) {
+        this.clock = checkNotNull(clock);
+    }
+
+    public static OnDemandDateFudger create(Clock clock) {
+        return new OnDemandDateFudger(clock);
+    }
+
+    public ItemOnDemandHierarchy fudgeStartDates(ItemOnDemandHierarchy onDemandHierarchy) {
+        Location resultLocation = onDemandHierarchy.location();
+
+        DateTime now = clock.now();
+
+        Policy policy = resultLocation.getPolicy();
+        if (policy != null && policy.getAvailabilityStart().isBefore(now)) {
+            Policy resultPolicy = policy.copy();
+            resultPolicy.setAvailabilityStart(now.minusHours(6));
+
+            resultLocation = resultLocation.copy();
+            resultLocation.setPolicy(resultPolicy);
+        }
+
+        return new ItemOnDemandHierarchy(
+                onDemandHierarchy.item(),
+                onDemandHierarchy.version(),
+                onDemandHierarchy.encoding(),
+                resultLocation
+        );
+    }
+}

--- a/src/main/java/org/atlasapi/feeds/tasks/youview/creation/TaskCreationTask.java
+++ b/src/main/java/org/atlasapi/feeds/tasks/youview/creation/TaskCreationTask.java
@@ -222,7 +222,7 @@ public abstract class TaskCreationTask extends ScheduledTask {
                     taskStore.save(taskCreator.taskFor(channelCrid, channel, p, action));
                     payloadHashStore.saveHash(HashType.CHANNEL, channelCrid, p.hash());
                 } else {
-                    log.debug("Existing hash found for Content {}, not updating", channelCrid);
+                    log.debug("Existing hash found for Channel {}, not updating", channelCrid);
                 }
             }
 
@@ -319,8 +319,12 @@ public abstract class TaskCreationTask extends ScheduledTask {
         e.printStackTrace(pw);
         return e.getMessage() + " " + sw.toString();
     }
-    
-    private UpdateProgress processOnDemand(String onDemandImi, ItemOnDemandHierarchy onDemandHierarchy) {
+
+    private UpdateProgress processOnDemand(
+            String onDemandImi,
+            ItemOnDemandHierarchy onDemandHierarchy
+    ) {
+
         Location location = onDemandHierarchy.location();
 
         Action action = location.getAvailable() ? Action.UPDATE : Action.DELETE;
@@ -345,16 +349,20 @@ public abstract class TaskCreationTask extends ScheduledTask {
 
             return UpdateProgress.SUCCESS;
         } catch (Exception e) {
-            log.error(String.format(
-                            "Failed to create payload for content %s, version %s, encoding %s, location %s",
-                            onDemandHierarchy.item().getCanonicalUri(),
-                            onDemandHierarchy.version().getCanonicalUri(),
-                            onDemandHierarchy.encoding().toString(),
-                            location.toString()
-                    ),
+            log.error(
+                    "Failed to create payload for content {}, version {}, encoding {}, location {}",
+                    onDemandHierarchy.item().getCanonicalUri(),
+                    onDemandHierarchy.version().getCanonicalUri(),
+                    onDemandHierarchy.encoding().toString(),
+                    location.toString(),
                     e
             );
-            Task task = taskStore.save(taskCreator.taskFor(onDemandImi, onDemandHierarchy, action, Status.FAILED));
+            Task task = taskStore.save(taskCreator.taskFor(
+                    onDemandImi,
+                    onDemandHierarchy,
+                    action,
+                    Status.FAILED
+            ));
             taskStore.updateWithLastError(task.id(), exceptionToString(e));
             return UpdateProgress.FAILURE;
         }

--- a/src/test/java/org/atlasapi/feeds/tasks/youview/creation/OnDemandDateFudgerTest.java
+++ b/src/test/java/org/atlasapi/feeds/tasks/youview/creation/OnDemandDateFudgerTest.java
@@ -1,0 +1,91 @@
+package org.atlasapi.feeds.tasks.youview.creation;
+
+import org.atlasapi.feeds.youview.hierarchy.ItemOnDemandHierarchy;
+import org.atlasapi.media.entity.Encoding;
+import org.atlasapi.media.entity.Item;
+import org.atlasapi.media.entity.Location;
+import org.atlasapi.media.entity.Policy;
+import org.atlasapi.media.entity.Version;
+
+import com.metabroadcast.common.time.Clock;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OnDemandDateFudgerTest {
+
+    @Mock private Clock clock;
+
+    @Mock private Item item;
+    @Mock private Version version;
+    @Mock private Encoding encoding;
+    @Mock private Location location;
+    @Mock private Policy policy;
+
+    private ItemOnDemandHierarchy hierarchy;
+    private OnDemandDateFudger fudger;
+    private DateTime now;
+
+    @Before
+    public void setUp() throws Exception {
+        now = DateTime.now();
+
+        when(location.getPolicy()).thenReturn(policy);
+        when(clock.now()).thenReturn(now);
+
+        hierarchy = new ItemOnDemandHierarchy(
+                item,
+                version,
+                encoding,
+                location
+        );
+
+        fudger = OnDemandDateFudger.create(clock);
+    }
+
+    @Test
+    public void availabilityInFutureGetsLeftAlone() throws Exception {
+        when(policy.getAvailabilityStart()).thenReturn(now.plusHours(1));
+
+        fudger.fudgeStartDates(hierarchy);
+
+        verify(policy, never()).copy();
+        verify(policy, never()).setAvailabilityStart(any(DateTime.class));
+    }
+
+    @Test
+    public void availabilityInPastGetsDateFudged() throws Exception {
+        when(policy.getAvailabilityStart()).thenReturn(now.minusHours(1));
+
+        Location locationCopy = mock(Location.class);
+        Policy policyCopy = mock(Policy.class);
+
+        when(location.copy()).thenReturn(locationCopy);
+        when(policy.copy()).thenReturn(policyCopy);
+
+        when(location.copy()).thenReturn(locationCopy);
+
+        ItemOnDemandHierarchy result = fudger.fudgeStartDates(hierarchy);
+
+        assertTrue(result.item() == item);
+        assertTrue(result.version() == version);
+        assertTrue(result.encoding() == encoding);
+        assertTrue(result.location() == locationCopy);
+
+        verify(locationCopy, times(1)).setPolicy(policyCopy);
+        verify(policyCopy, times(1)).setAvailabilityStart(now.minusHours(6));
+    }
+}


### PR DESCRIPTION
This is a hack around The Beeb deleting availabilities, then reinstating them, and that process
interacting with our hash logic. Fudging the dates before generating the payloads makes sure we
bust the hashes and resend an OD to YV.