### PR TITLE
Hotfix upload to YouView

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-applications</artifactId>
-            <version>${atlas.version}</version>
+            <version>5.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>xerces</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-feeds</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.atlasapi</groupId>
             <artifactId>atlas-applications</artifactId>
-            <version>5.0-SNAPSHOT</version>
+            <version>${atlas.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>xerces</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-feeds</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.7-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/src/main/java/org/atlasapi/feeds/youview/YouviewContentMerger.java
+++ b/src/main/java/org/atlasapi/feeds/youview/YouviewContentMerger.java
@@ -1,5 +1,6 @@
 package org.atlasapi.feeds.youview;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.metabroadcast.representative.util.Utils.decode;
-
+import static org.atlasapi.output.Annotation.RESPECT_API_KEY_FOR_EQUIV_LIST;
 
 public class YouviewContentMerger {
 
@@ -74,6 +75,8 @@ public class YouviewContentMerger {
                 .withSelection(Selection.all())
                 .withApplication(application)
                 .build();
+
+        contentQuery = contentQuery.copyWithAnnotations(Collections.singleton(RESPECT_API_KEY_FOR_EQUIV_LIST));
 
         Map<String, List<Identified>> mergedResults =
                 mergingResolver.executeUriQuery(


### PR DESCRIPTION
Related to CPINC-1896 ENG-557

The equivAndMerge part of uploading to YouView will now
correctly only look at equivs which are from sources that are
enabled on the apikey. This was always intended behaviour
(the annotation was created specifically for this), but was likely
simply omitted from the original implementation.