### PR TITLE
Change /feeds/youview/{publisher}/delete endpoint to also update the YouviewPayloadHashStore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     </repositories>
 
     <properties>
-        <atlas.version>5.0</atlas.version>
+        <atlas.version>5.0-SNAPSHOT</atlas.version>
 
         <spring.version>4.0.9.RELEASE</spring.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     </repositories>
 
     <properties>
-        <atlas.version>${project.version}</atlas.version>
+        <atlas.version>5.0</atlas.version>
 
         <spring.version>4.0.9.RELEASE</spring.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-feeds</artifactId>
-    <version>5.071-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -330,7 +330,7 @@
     </repositories>
 
     <properties>
-        <atlas.version>5.0-SNAPSHOT</atlas.version>
+        <atlas.version>${project.version}</atlas.version>
 
         <spring.version>4.0.9.RELEASE</spring.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-feeds</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.071-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/src/main/java/org/atlasapi/feeds/youview/YouViewUploadModule.java
+++ b/src/main/java/org/atlasapi/feeds/youview/YouViewUploadModule.java
@@ -272,6 +272,7 @@ public class YouViewUploadModule {
                 .withScheduleResolver(scheduleResolver)
                 .withChannelResolver(channelResolver)
                 .withClock(clock)
+                .withPayloadHashStore(payloadHashStore())
                 .build();
     }
 


### PR DESCRIPTION
When investigating MTS-1317 it was found that the youview-disparity-fixer was hitting an endpoint in this project that deleted content from youview, but did not update the payloadHashStore collection in Mongo, which stores hashes of YouView uploads. This meant that if in the future the unchanged content was reuploaded, the payloadHashStore would be checked for upload fragment hashes, and because the content was unchanged, the hashes would match and the content would not be reuploaded. This fix ensures that the payloadHashStore collection is properly updated with deletes from the /feeds/youview/{publisher}/delete endpoint.