### PR TITLE
Allow YouView Delete endpoint to accept an empty uri

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-feeds</artifactId>
-    <version>5.071-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -330,7 +330,7 @@
     </repositories>
 
     <properties>
-        <atlas.version>5.0-SNAPSHOT</atlas.version>
+        <atlas.version>${project.version}</atlas.version>
 
         <spring.version>4.0.9.RELEASE</spring.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-feeds</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.071-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -330,7 +330,7 @@
     </repositories>
 
     <properties>
-        <atlas.version>${project.version}</atlas.version>
+        <atlas.version>5.0-SNAPSHOT</atlas.version>
 
         <spring.version>4.0.9.RELEASE</spring.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>

--- a/src/main/java/org/atlasapi/feeds/youview/www/YouViewUploadController.java
+++ b/src/main/java/org/atlasapi/feeds/youview/www/YouViewUploadController.java
@@ -976,7 +976,7 @@ public class YouViewUploadController {
         // TODO ideally this would go via the TaskCreator, but that would require resolving
         // the hierarchies for each type of element
         Destination destination = new YouViewDestination(
-                content == null ? null : content.getCanonicalUri(),
+                content == null ? "" : content.getCanonicalUri(),
                 type,
                 elementId
         );

--- a/src/main/java/org/atlasapi/feeds/youview/www/YouViewUploadController.java
+++ b/src/main/java/org/atlasapi/feeds/youview/www/YouViewUploadController.java
@@ -919,7 +919,7 @@ public class YouViewUploadController {
     public void deleteContent(
             HttpServletResponse response,
             @PathVariable("publisher") String publisherStr,
-            @RequestParam(value = "uri") String uri,
+            @RequestParam(value = "uri", required = false) String uri,
             @RequestParam(value = "element_id") String elementId,
             @RequestParam(value = "type") String typeStr
     ) throws IOException {

--- a/src/main/java/org/atlasapi/feeds/youview/www/YouViewUploadController.java
+++ b/src/main/java/org/atlasapi/feeds/youview/www/YouViewUploadController.java
@@ -1013,8 +1013,10 @@ public class YouViewUploadController {
                             .append(contributingUris)
                             .toString()
             );
-        } else {
+        } else if (uri != null) {
             sendOkResponse(response, "Delete for " + uri + " sent successfully ");
+        } else {
+            sendOkResponse(response, "Delete for " + elementId + " sent successfully ");
         }
     }
 


### PR DESCRIPTION
This allows for specific elementIds to be removed without
knowing the uri of the content. This is helpful when the 
imi has been obliterated from the content and cannot be
recreated, and used by the yv disparity fixer to remove
imis.

An attempt was made to allow the above behaviour to work
without affecting what was already happening here, even
though it appears that what is already happening is so
unintuitive it can be called wrong.